### PR TITLE
🔀 Merging Exercise 1.3.1 branch into main

### DIFF
--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 1,
    "id": "65fb0698",
    "metadata": {},
    "outputs": [],
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "331a320e",
+   "id": "afd4e1b9",
    "metadata": {},
    "source": [
     "In this exercise we will implement the following functions:\n",
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "153113ba",
+   "id": "03783ac4",
    "metadata": {},
    "source": [
     "## 1. Introduction"
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "2308d786",
+   "id": "fabd5aa0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "9188c02c",
+   "id": "095ce856",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "38607790",
+   "id": "fa4312f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "02bfb36f",
+   "id": "690bd869",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4d6db820",
+   "id": "1f78e4dc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "bbb7c93d",
+   "id": "5f4c726c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "493ffc8e",
+   "id": "8b3420c9",
    "metadata": {},
    "source": [
     "### 1.1. Softmax"
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "483020bd",
+   "id": "08d54b95",
    "metadata": {},
    "source": [
     "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2b1f8ed",
+   "id": "c1b342e7",
    "metadata": {},
    "source": [
     "##### Note on numerical stability"
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9ce3acf",
+   "id": "8a7cf833",
    "metadata": {},
    "source": [
     "Exponentiation in Python can be a problem for larger numbers. A Numpy `float64` value can represent a maximal number on the order of $10^{308}$, but with exponentiation in the softmax function it is possible to overshoot this number, even for fairly modest-sized inputs (as pointed out in [this](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) post by E. Bendersky).\n",
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afe82f54",
+   "id": "97e26ba7",
    "metadata": {},
    "source": [
     "### 1.2. Cross-entropy"
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7309acfc",
+   "id": "e50394bc",
    "metadata": {},
    "source": [
     "In machine learning, [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_loss_function_and_logistic_regression) is often used as a loss function computed between two probability distributions. Given a set of predictions $q_{i}$ and corresponding true probability values $p_{i}$ we can compute the cross-entropy loss, i.e., _log loss_ [1],\n",
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b49ca1fb",
+   "id": "4eee70b4",
    "metadata": {},
    "source": [
     "#### Cross-entropy loss function"
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f4e32f4",
+   "id": "053334cb",
    "metadata": {},
    "source": [
     "The cross-entropy loss function is defined for a training sample $x_{i}$ belonging to class $j$ as\n",
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48fd42ea",
+   "id": "a9ceded1",
    "metadata": {},
    "source": [
     "## 2. Programming Task"
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fedb148",
+   "id": "aae9a982",
    "metadata": {},
    "source": [
     "### 2.1. Softmax"
@@ -286,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 9,
    "id": "d144aedb",
    "metadata": {},
    "outputs": [],
@@ -310,8 +310,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
-   "id": "1ab041f0",
+   "execution_count": 10,
+   "id": "79d463a2",
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +321,7 @@
        "       0.10902364, 0.29635698])"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -335,17 +335,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
-   "id": "5ff7ec9e",
+   "execution_count": 11,
+   "id": "e5b52d63",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/wf/qk186lys1kd1yhnstdfyjjr80000gn/T/ipykernel_87737/1200169668.py:14: RuntimeWarning: overflow encountered in exp\n",
+      "/var/folders/wf/qk186lys1kd1yhnstdfyjjr80000gn/T/ipykernel_95838/2716306856.py:14: RuntimeWarning: overflow encountered in exp\n",
       "  soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n",
-      "/var/folders/wf/qk186lys1kd1yhnstdfyjjr80000gn/T/ipykernel_87737/1200169668.py:14: RuntimeWarning: invalid value encountered in true_divide\n",
+      "/var/folders/wf/qk186lys1kd1yhnstdfyjjr80000gn/T/ipykernel_95838/2716306856.py:14: RuntimeWarning: invalid value encountered in true_divide\n",
       "  soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n"
      ]
     },
@@ -355,7 +355,7 @@
        "array([nan, nan, nan])"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,8 +368,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
-   "id": "85209812",
+   "execution_count": 12,
+   "id": "f0ec6f76",
    "metadata": {},
    "outputs": [
     {
@@ -378,7 +378,7 @@
        "array([0., 0., 1.])"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -391,7 +391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89f978eb",
+   "id": "22be8249",
    "metadata": {},
    "source": [
     "**Note**: this output isn't very ideal either, since the softmax function does not typically result in a zero value. However, for very large numbers, we are expecting a result extremely close to zero anyway."
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "faea6156",
+   "id": "d46c29ca",
    "metadata": {},
    "source": [
     "### 2.2. Cross-entropy"
@@ -415,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 13,
    "id": "ae0b187c",
    "metadata": {},
    "outputs": [],
@@ -425,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 14,
    "id": "340e7f8e",
    "metadata": {},
    "outputs": [],
@@ -435,24 +435,24 @@
     "    \n",
     "    :param scaled_logits: an NxC tensor of scaled softmax\n",
     "        distribution values, [n_samples x n_classes].\n",
-    "    :param one_hot: an CxN tensor of one-hot encoded \n",
-    "        ground truth labels, [n_classes x n_samples].\n",
+    "    :param one_hot: an NxC tensor of one-hot encoded \n",
+    "        ground truth labels, [n_samples x n_classes].\n",
     "    :returns: loss, a 1x1 tensor with cross-entropy loss. \n",
     "    \"\"\"\n",
     "    \n",
     "    # TODO: perform on tensor objects\n",
-    "    assert scaled_logits.shape == one_hot.T.shape\n",
-    "    n_classes = one_hot.shape[0]\n",
+    "    assert scaled_logits.shape == one_hot.shape\n",
+    "    n_samples = one_hot.shape[0]\n",
     "    class_label = one_hot.argmax(axis=1)\n",
-    "    log_likelihood = -np.log(scaled_logits[:n_classes, class_label])\n",
-    "    loss = np.sum(log_likelihood) / n_classes\n",
+    "    log_likelihood = -np.log(scaled_logits[range(n_samples), class_label])\n",
+    "    loss = np.sum(log_likelihood) / n_samples\n",
     "    return loss"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
-   "id": "be3caa17",
+   "execution_count": 15,
+   "id": "e714945d",
    "metadata": {},
    "outputs": [
     {
@@ -467,7 +467,7 @@
        "       [0., 0., 0., 1.]], dtype=float32)"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -481,47 +481,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
-   "id": "ca2f43ca",
+   "execution_count": 16,
+   "id": "aac11f8c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
-       "        0.10902364, 0.29635698],\n",
-       "       [0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
-       "        0.10902364, 0.29635698],\n",
-       "       [0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
-       "        0.10902364, 0.29635698],\n",
-       "       [0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
-       "        0.10902364, 0.29635698]])"
+       "array([[0.04010756, 0.04010756, 0.04010756, 0.04010756],\n",
+       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
+       "       [0.29635698, 0.29635698, 0.29635698, 0.29635698],\n",
+       "       [0.04010756, 0.04010756, 0.04010756, 0.04010756],\n",
+       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
+       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
+       "       [0.29635698, 0.29635698, 0.29635698, 0.29635698]])"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "### Creating pseudo-batched data by repeating 'predictions'\n",
-    "X_scaled = np.stack([x_scaled] * 4)\n",
+    "X_scaled = np.stack([x_scaled] * 4, axis=1)\n",
     "X_scaled"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
-   "id": "12b86f4b",
+   "execution_count": 17,
+   "id": "81e2bccc",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "8.864762120074198"
+       "2.216190530018549"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -534,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98de1fa3",
+   "id": "52c767e1",
    "metadata": {},
    "source": [
     "### 2.3. Logistic Regression model"
@@ -550,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "6b8cf3c2",
    "metadata": {},
    "outputs": [],
@@ -560,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "92083e35",
    "metadata": {},
    "outputs": [],
@@ -581,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa7151ec",
+   "id": "40cc8c31",
    "metadata": {},
    "source": [
     "### 2.4. Prediction accuracy"
@@ -597,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "06181bb3",
    "metadata": {},
    "outputs": [],
@@ -607,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "4bf1feff",
    "metadata": {},
    "outputs": [],
@@ -644,7 +643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0726f8a5",
+   "id": "8356acbd",
    "metadata": {},
    "source": [
     "## Credits\n",
@@ -659,14 +658,6 @@
     "* [The Softmax function and its derivative | E. Bendersky](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/)\n",
     "* [Softmax and Cross Entropy Loss | P. Dahal](https://deepnotes.io/softmax-crossentropy)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15996404",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -5,18 +5,23 @@
    "id": "03b73b05",
    "metadata": {},
    "source": [
-    "# Exercise 1 - Logistic Regression"
+    "# Exercise 1.3.1 - Logistic Regression"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "65fb0698",
+   "cell_type": "markdown",
+   "id": "226d04ed",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import tensorflow as tf\n",
-    "from tensorflow.keras import utils"
+    "#### By Jonathan L. Moran (jonathan.moran107@gmail.com)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b979664f",
+   "metadata": {},
+   "source": [
+    "From the Self-Driving Car Engineer Nanodegree programme offered at Udacity."
    ]
   },
   {
@@ -29,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afd4e1b9",
+   "id": "ac1be90b",
    "metadata": {},
    "source": [
     "In this exercise we will implement the following functions:\n",
@@ -41,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03783ac4",
+   "id": "b24afe77",
    "metadata": {},
    "source": [
     "## 1. Introduction"
@@ -49,8 +54,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "fabd5aa0",
+   "execution_count": 1,
+   "id": "d5605c6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,19 +64,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "095ce856",
+   "execution_count": 2,
+   "id": "15f55668",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import os"
+    "import os\n",
+    "import tensorflow as tf\n",
+    "import tensorflow.experimental.numpy as tnp\n",
+    "from tensorflow.keras import utils"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "fa4312f4",
+   "execution_count": 3,
+   "id": "de001b48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,8 +88,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "690bd869",
+   "execution_count": 4,
+   "id": "b70fb15b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,8 +98,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "1f78e4dc",
+   "execution_count": 5,
+   "id": "9de4350c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,8 +109,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "5f4c726c",
+   "execution_count": 6,
+   "id": "f651f693",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b3420c9",
+   "id": "a12ea3f8",
    "metadata": {},
    "source": [
     "### 1.1. Softmax"
@@ -122,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08d54b95",
+   "id": "e4ee36bd",
    "metadata": {},
    "source": [
     "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
@@ -146,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1b342e7",
+   "id": "c43814d3",
    "metadata": {},
    "source": [
     "##### Note on numerical stability"
@@ -154,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a7cf833",
+   "id": "c9abe1c2",
    "metadata": {},
    "source": [
     "Exponentiation in Python can be a problem for larger numbers. A Numpy `float64` value can represent a maximal number on the order of $10^{308}$, but with exponentiation in the softmax function it is possible to overshoot this number, even for fairly modest-sized inputs (as pointed out in [this](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) post by E. Bendersky).\n",
@@ -180,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97e26ba7",
+   "id": "b183d4c8",
    "metadata": {},
    "source": [
     "### 1.2. Cross-entropy"
@@ -188,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e50394bc",
+   "id": "ef1b9984",
    "metadata": {},
    "source": [
     "In machine learning, [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_loss_function_and_logistic_regression) is often used as a loss function computed between two probability distributions. Given a set of predictions $q_{i}$ and corresponding true probability values $p_{i}$ we can compute the cross-entropy loss, i.e., _log loss_ [1],\n",
@@ -213,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4eee70b4",
+   "id": "4e9057c4",
    "metadata": {},
    "source": [
     "#### Cross-entropy loss function"
@@ -221,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "053334cb",
+   "id": "f3f03b25",
    "metadata": {},
    "source": [
     "The cross-entropy loss function is defined for a training sample $x_{i}$ belonging to class $j$ as\n",
@@ -244,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9ceded1",
+   "id": "1ddfc7f1",
    "metadata": {},
    "source": [
     "## 2. Programming Task"
@@ -252,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aae9a982",
+   "id": "8d8d3dfa",
    "metadata": {},
    "source": [
     "### 2.1. Softmax"
@@ -276,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "b539cdeb",
    "metadata": {},
    "outputs": [],
@@ -286,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "d144aedb",
    "metadata": {},
    "outputs": [],
@@ -294,31 +302,68 @@
     "def softmax(logits, stable=False):\n",
     "    \"\"\"Returns the softmax probability distribution.\n",
     "    \n",
-    "    :param logits: a 1xN tensor of logits.\n",
+    "    :param logits: a 1xN tf.Tensor of logits.\n",
     "    :param stable: optional, flag indicating whether\n",
     "        or not to normalise the input data.\n",
-    "    returns: soft_logits, an 1xN tensor of real values\n",
-    "        in range (0,1) that sum up to 1.0.\n",
+    "    returns: soft_logits, a 1xN tf.Tensor of real \n",
+    "        values in range (0,1) that sum up to 1.0.\n",
     "    \"\"\"\n",
     "    \n",
-    "    # TODO: perform on tensor objects\n",
+    "    assert isinstance(logits, tf.Tensor)\n",
     "    if stable:\n",
-    "        logits -= np.max(logits)\n",
-    "    soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n",
+    "        logits = tf.subtract(logits, tf.reduce_max(logits))\n",
+    "    soft_logits = tf.math.exp(logits)\n",
+    "    soft_logits /= tf.math.reduce_sum(soft_logits)\n",
     "    return soft_logits"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "79d463a2",
+   "execution_count": 9,
+   "id": "b22ac0e6",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-08-28 19:41:36.465409: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
+      "2022-08-28 19:41:36.466833: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "array([0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
        "       0.10902364, 0.29635698])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "### Testing the softmax function with N=7 predictions\n",
+    "x = [1.0, 2.0, 3.0, 1.0, 2.0, 2.0, 3.0]\n",
+    "### Converting to tf.Tensor object\n",
+    "x = tf.constant(x, dtype=tf.float64)\n",
+    "### Computing the softmax function and printing results as Numpy array\n",
+    "x_scaled = softmax(x)\n",
+    "x_scaled.numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c7b62cdf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(3,), dtype=float64, numpy=array([nan, nan, nan])>"
       ]
      },
      "execution_count": 10,
@@ -327,32 +372,21 @@
     }
    ],
    "source": [
-    "### Testing the softmax function with N=7 predictions\n",
-    "x = [1.0, 2.0, 3.0, 1.0, 2.0, 2.0, 3.0]\n",
-    "x_scaled = softmax(x)\n",
-    "x_scaled"
+    "### Testing the softmax function with N=3 large values (without normalising)\n",
+    "x_large = tf.constant([1000, 2000, 3000], dtype=tf.float64)\n",
+    "softmax(x_large)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "e5b52d63",
+   "id": "307037d8",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/wf/qk186lys1kd1yhnstdfyjjr80000gn/T/ipykernel_95838/2716306856.py:14: RuntimeWarning: overflow encountered in exp\n",
-      "  soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n",
-      "/var/folders/wf/qk186lys1kd1yhnstdfyjjr80000gn/T/ipykernel_95838/2716306856.py:14: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "array([nan, nan, nan])"
+       "<tf.Tensor: shape=(3,), dtype=float64, numpy=array([0., 0., 1.])>"
       ]
      },
      "execution_count": 11,
@@ -361,37 +395,14 @@
     }
    ],
    "source": [
-    "### Testing the softmax function with N=3 large values (without normalising)\n",
-    "x_large = [1000, 2000, 3000]\n",
-    "softmax(x_large)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "f0ec6f76",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0., 0., 1.])"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
     "### Testing the softmax function with N=3 large values (with normalising)\n",
-    "x_large = [1000, 2000, 3000]\n",
+    "x_large = tf.constant([1000, 2000, 3000], dtype=tf.float64)\n",
     "softmax(x_large, stable=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "22be8249",
+   "id": "aca89c15",
    "metadata": {},
    "source": [
     "**Note**: this output isn't very ideal either, since the softmax function does not typically result in a zero value. However, for very large numbers, we are expecting a result extremely close to zero anyway."
@@ -399,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d46c29ca",
+   "id": "f9b098e5",
    "metadata": {},
    "source": [
     "### 2.2. Cross-entropy"
@@ -415,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "ae0b187c",
    "metadata": {},
    "outputs": [],
@@ -425,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "340e7f8e",
    "metadata": {},
    "outputs": [],
@@ -433,38 +444,74 @@
     "def cross_entropy(scaled_logits, one_hot):\n",
     "    \"\"\"Returns the cross-entropy loss.\n",
     "    \n",
-    "    :param scaled_logits: an NxC tensor of scaled softmax\n",
+    "    :param scaled_logits: an NxC tf.Tensor of scaled softmax\n",
     "        distribution values, [n_samples x n_classes].\n",
-    "    :param one_hot: an NxC tensor of one-hot encoded \n",
+    "    :param one_hot: an NxC tf.Tensor of one-hot encoded \n",
     "        ground truth labels, [n_samples x n_classes].\n",
-    "    :returns: loss, a 1x1 tensor with cross-entropy loss. \n",
+    "    :returns: loss, a 1x1 tf.Tensor with cross-entropy loss. \n",
     "    \"\"\"\n",
     "    \n",
-    "    # TODO: perform on tensor objects\n",
-    "    assert scaled_logits.shape == one_hot.shape\n",
+    "    assert isinstance(scaled_logits, tf.Tensor)\n",
+    "    assert isinstance(one_hot, tf.Tensor)\n",
+    "    assert scaled_logits.shape == y_one_hot.shape\n",
     "    n_samples = one_hot.shape[0]\n",
-    "    class_label = one_hot.argmax(axis=1)\n",
-    "    log_likelihood = -np.log(scaled_logits[range(n_samples), class_label])\n",
-    "    loss = np.sum(log_likelihood) / n_samples\n",
+    "    class_labels = tf.math.argmax(one_hot, axis=1)\n",
+    "    # For each sample, pick the probability value from the distribution\n",
+    "    # that corresponds to the true class label\n",
+    "    preds = tnp.asarray(scaled_logits)[range(n_samples), class_labels]\n",
+    "    log_likelihood = -tf.math.log(preds)\n",
+    "    loss = tf.math.reduce_sum(log_likelihood) / n_samples\n",
     "    return loss"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "e714945d",
+   "execution_count": 14,
+   "id": "17922ebe",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
+       "<tf.Tensor: shape=(7, 4), dtype=float32, numpy=\n",
        "array([[0., 0., 1., 0.],\n",
        "       [0., 0., 1., 0.],\n",
        "       [0., 0., 0., 1.],\n",
        "       [1., 0., 0., 0.],\n",
        "       [0., 0., 1., 0.],\n",
        "       [0., 1., 0., 0.],\n",
-       "       [0., 0., 0., 1.]], dtype=float32)"
+       "       [0., 0., 0., 1.]], dtype=float32)>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Creating our ground-truth labels and using one-hot encoding\n",
+    "y = tf.constant([2.0, 2.0, 3.0, 0.0, 2.0, 1.0, 3.0])\n",
+    "y_one_hot = tf.constant(tf.keras.utils.to_categorical(y))\n",
+    "y_one_hot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c7e9170a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: shape=(7, 4), dtype=float64, numpy=\n",
+       "array([[0.04010756, 0.04010756, 0.04010756, 0.04010756],\n",
+       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
+       "       [0.29635698, 0.29635698, 0.29635698, 0.29635698],\n",
+       "       [0.04010756, 0.04010756, 0.04010756, 0.04010756],\n",
+       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
+       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
+       "       [0.29635698, 0.29635698, 0.29635698, 0.29635698]])>"
       ]
      },
      "execution_count": 15,
@@ -473,54 +520,24 @@
     }
    ],
    "source": [
-    "# Creating our ground-truth labels and using one-hot encoding\n",
-    "y = np.array([2.0, 2.0, 3.0, 0.0, 2.0, 1.0, 3.0])\n",
-    "y_one_hot = utils.to_categorical(y, num_classes=np.unique(y).shape[0])\n",
-    "y_one_hot"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "aac11f8c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.04010756, 0.04010756, 0.04010756, 0.04010756],\n",
-       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
-       "       [0.29635698, 0.29635698, 0.29635698, 0.29635698],\n",
-       "       [0.04010756, 0.04010756, 0.04010756, 0.04010756],\n",
-       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
-       "       [0.10902364, 0.10902364, 0.10902364, 0.10902364],\n",
-       "       [0.29635698, 0.29635698, 0.29635698, 0.29635698]])"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
     "### Creating pseudo-batched data by repeating 'predictions'\n",
-    "X_scaled = np.stack([x_scaled] * 4, axis=1)\n",
+    "X_scaled = tf.stack([x_scaled] * 4, axis=1)\n",
     "X_scaled"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "81e2bccc",
+   "execution_count": 16,
+   "id": "479b9123",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2.216190530018549"
+       "<tf.Tensor: shape=(), dtype=float64, numpy=2.216190530018549>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,7 +550,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52c767e1",
+   "id": "e327561a",
    "metadata": {},
    "source": [
     "### 2.3. Logistic Regression model"
@@ -549,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "6b8cf3c2",
    "metadata": {},
    "outputs": [],
@@ -559,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "92083e35",
    "metadata": {},
    "outputs": [],
@@ -580,7 +597,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40cc8c31",
+   "id": "bb28285f",
    "metadata": {},
    "source": [
     "### 2.4. Prediction accuracy"
@@ -596,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "06181bb3",
    "metadata": {},
    "outputs": [],
@@ -606,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "4bf1feff",
    "metadata": {},
    "outputs": [],
@@ -643,7 +660,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8356acbd",
+   "id": "a90acbad",
    "metadata": {},
    "source": [
     "## Credits\n",

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "65fb0698",
    "metadata": {},
    "outputs": [],
@@ -23,7 +23,140 @@
    "id": "911bfcb4",
    "metadata": {},
    "source": [
-    "## Objective"
+    "## Objectives"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58bffe29",
+   "metadata": {},
+   "source": [
+    "In this exercise we will implement the following functions:\n",
+    "* `softmax`: computes the softmax (normalised exponential function) of a input tensor;\n",
+    "* `cross_entropy`: calculates the cross-entropy loss between one-hot encoded prediction and ground truth vectors;\n",
+    "* `model`: logistic regression algorithm;\n",
+    "* `accuracy`: calculates the accuracy between a set of predictions and corresponding ground truth labels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9dac69d",
+   "metadata": {},
+   "source": [
+    "## 1. Introduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a59ca631",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Importing required modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0e824358",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b56eab3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Setting environment variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d863b024",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENV_COLAB = False                # True if running in Google Colab instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9ae4ce0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Root directory\n",
+    "DIR_BASE = '' if not ENV_COLAB else '/content/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e3e23b29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subdirectory to save output files\n",
+    "DIR_OUT = os.path.join(DIR_BASE, 'out/')\n",
+    "# Subdirectory pointing to input data\n",
+    "DIR_SRC = os.path.join(DIR_BASE, 'data/')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e503b95",
+   "metadata": {},
+   "source": [
+    "### 1.1. Softmax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c16f4ca",
+   "metadata": {},
+   "source": [
+    "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "    P\\left(y=j \\ \\vert \\ z_{i}\\right) = \\phi_{softmax}\\left(z_{i}\\right) \n",
+    "    = \\frac{\\mathcal{e}^{z_{i}}}{\\sum_{j=0}^{k}\\mathcal{e}^{z_{k}^{i}}}.\n",
+    "    \\end{align}\n",
+    "$$\n",
+    "The input $z$ is defined to be\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "    z &= w_{0}x_{0} + w_{1}x_{1} + \\ldots + w_{m}x_{m} = \\sum_{i=0}^{m} w_{i}x_{i} = \\mathrm{w}^{\\top}\\mathrm{x}.\n",
+    "    \\end{align}\n",
+    "$$\n",
+    "such that $\\mathrm{w}$ is the weight vector, $\\mathrm{x}$ is the feature vector belonging to a single training observation, and $w_{0}$ is the bias unit.\n",
+    "\n",
+    "The softmax function computes the probability for each class $P\\left(y=j \\vert x_{i}; w_{j}\\right)$, then a correction step is applied to the predictions during training using a cost function that minimises the cross-entropy over the training set observations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b3ed8e6",
+   "metadata": {},
+   "source": [
+    "## 2. Programming Task"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22d4e643",
+   "metadata": {},
+   "source": [
+    "### 2.1. Softmax"
    ]
   },
   {
@@ -44,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b539cdeb",
    "metadata": {},
    "outputs": [],
@@ -54,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "d144aedb",
    "metadata": {},
    "outputs": [],
@@ -68,7 +201,41 @@
     "    - soft_logits [tensor]: softmax of logits\n",
     "    \"\"\"\n",
     "    # IMPLEMENT THIS FUNCTION\n",
+    "    \n",
+    "    soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n",
     "    return soft_logits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fcadaedb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.02364054, 0.06426166, 0.1746813 , 0.474833  , 0.02364054,\n",
+       "       0.06426166, 0.1746813 ])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "### Testing the softmax function\n",
+    "a = [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0]\n",
+    "softmax(a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "624c3489",
+   "metadata": {},
+   "source": [
+    "### 2.2. Cross-entropy"
    ]
   },
   {
@@ -81,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "ae0b187c",
    "metadata": {},
    "outputs": [],
@@ -91,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "340e7f8e",
    "metadata": {},
    "outputs": [],
@@ -111,6 +278,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3f7a0b25",
+   "metadata": {},
+   "source": [
+    "### 2.3. Logistic Regression model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b9fa6d04",
    "metadata": {},
    "source": [
@@ -119,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "6b8cf3c2",
    "metadata": {},
    "outputs": [],
@@ -129,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "92083e35",
    "metadata": {},
    "outputs": [],
@@ -150,6 +325,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6aef47e0",
+   "metadata": {},
+   "source": [
+    "### 2.4. Prediction accuracy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c0aca75b",
    "metadata": {},
    "source": [
@@ -158,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "06181bb3",
    "metadata": {},
    "outputs": [],
@@ -168,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "4bf1feff",
    "metadata": {},
    "outputs": [],
@@ -201,6 +384,21 @@
    "source": [
     "You can leverage the `tf.boolean_mask` function to calculate the cross entropy. Keep in mind\n",
     "that most elements of the ground truth vector are zeros."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74a3db93",
+   "metadata": {},
+   "source": [
+    "## Credits\n",
+    "This assignment was prepared by Thomas Hossler and Michael Virgo et al., Winter 2021 (link [here](https://www.udacity.com/course/self-driving-car-engineer-nanodegree--nd0013)).\n",
+    "\n",
+    "References\n",
+    "\n",
+    "\n",
+    "Helpful resources:\n",
+    "* [Softmax Regression and How is it Related to Logistic Regression? | KDnuggets](https://www.kdnuggets.com/2016/07/softmax-regression-related-logistic-regression.html)"
    ]
   }
  ],

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -1,0 +1,241 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "03b73b05",
+   "metadata": {},
+   "source": [
+    "# Exercise 1 - Logistic Regression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65fb0698",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "911bfcb4",
+   "metadata": {},
+   "source": [
+    "## Objective"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dd5d459",
+   "metadata": {},
+   "source": [
+    "In this exercise, you have to implement 4 different functions:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8128d23",
+   "metadata": {},
+   "source": [
+    "* `softmax`: compute the softmax of a vector. This function takes as input a tensor and outputs a discrete probability distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b539cdeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### From Udacity's `logistic.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d144aedb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def softmax(logits):\n",
+    "    \"\"\"\n",
+    "    softmax implementation\n",
+    "    args:\n",
+    "    - logits [tensor]: 1xN logits tensor\n",
+    "    returns:\n",
+    "    - soft_logits [tensor]: softmax of logits\n",
+    "    \"\"\"\n",
+    "    # IMPLEMENT THIS FUNCTION\n",
+    "    return soft_logits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "780ba4a0",
+   "metadata": {},
+   "source": [
+    "* `cross_entropy`: calculate the cross entropy loss given a vector of predictions (after softmax) and a vector of ground truth (one-hot vector)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae0b187c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### From Udacity's `logistic.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "340e7f8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cross_entropy(scaled_logits, one_hot):\n",
+    "    \"\"\"\n",
+    "    Cross entropy loss implementation\n",
+    "    args:\n",
+    "    - scaled_logits [tensor]: NxC tensor where N batch size / C number of classes\n",
+    "    - one_hot [tensor]: one hot tensor\n",
+    "    returns:\n",
+    "    - loss [tensor]: cross entropy \n",
+    "    \"\"\"\n",
+    "    # IMPLEMENT THIS FUNCTION\n",
+    "    return nll"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9fa6d04",
+   "metadata": {},
+   "source": [
+    "* `model`: takes a batch of images (stack of images along the first dimensions) and feeds it through the logistic regression model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b8cf3c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### From Udacity's `logistic.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92083e35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def model(X, W, b):\n",
+    "    \"\"\"\n",
+    "    logistic regression model\n",
+    "    args:\n",
+    "    - X [tensor]: input HxWx3\n",
+    "    - W [tensor]: weights\n",
+    "    - b [tensor]: bias\n",
+    "    returns:\n",
+    "    - output [tensor]\n",
+    "    \"\"\"\n",
+    "    # IMPLEMENT THIS FUNCTION\n",
+    "    return "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0aca75b",
+   "metadata": {},
+   "source": [
+    "* `accuracy`: given a vector of predictions and a vector of ground truth, calculate the accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06181bb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### From Udacity's `logistic.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bf1feff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def accuracy(y_hat, Y):\n",
+    "    \"\"\"\n",
+    "    calculate accuracy\n",
+    "    args:\n",
+    "    - y_hat [tensor]: NxC tensor of models predictions\n",
+    "    - y [tensor]: N tensor of ground truth classes\n",
+    "    returns:\n",
+    "    - acc [tensor]: accuracy\n",
+    "    \"\"\"\n",
+    "    # IMPLEMENT THIS FUNCTION\n",
+    "    return acc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17d8b2e1",
+   "metadata": {},
+   "source": [
+    "## Tips"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be159df3",
+   "metadata": {},
+   "source": [
+    "You can leverage the `tf.boolean_mask` function to calculate the cross entropy. Keep in mind\n",
+    "that most elements of the ground truth vector are zeros."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -10,12 +10,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 36,
    "id": "65fb0698",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tensorflow as tf"
+    "import tensorflow as tf\n",
+    "from tensorflow.keras import utils"
    ]
   },
   {
@@ -28,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58bffe29",
+   "id": "f1501ac3",
    "metadata": {},
    "source": [
     "In this exercise we will implement the following functions:\n",
@@ -40,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9dac69d",
+   "id": "010dcb91",
    "metadata": {},
    "source": [
     "## 1. Introduction"
@@ -49,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a59ca631",
+   "id": "d2983a13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "0e824358",
+   "id": "b3f0b4c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b56eab3d",
+   "id": "7d88c5c2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d863b024",
+   "id": "27fa02d1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "9ae4ce0e",
+   "id": "fbbfa20a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "e3e23b29",
+   "id": "b05aa651",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e503b95",
+   "id": "aba03402",
    "metadata": {},
    "source": [
     "### 1.1. Softmax"
@@ -121,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c16f4ca",
+   "id": "21be5228",
    "metadata": {},
    "source": [
     "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
@@ -145,7 +146,71 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b3ed8e6",
+   "id": "a9476d5d",
+   "metadata": {},
+   "source": [
+    "### 1.2. Cross-entropy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81fb2f35",
+   "metadata": {},
+   "source": [
+    "In machine learning, [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_loss_function_and_logistic_regression) is often used as a loss function computed between two probability distributions. Given a set of predictions $q_{i}$ and corresponding true probability values $p_{i}$ we can compute the cross-entropy loss, i.e., _log loss_ [1],\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "    H\\left(p,q\\right) = -\\sum_{i}{p_i}\\mathrm{log}q_i = -ylog\\hat{y} - \\left(1-y\\right)\\mathrm{log}\\left(1-\\hat{y}\\right)\n",
+    "    \\end{align}\n",
+    "$$\n",
+    "\n",
+    "which serves as a measure of dissimilarity between $p$ and $q$.\n",
+    "\n",
+    "For a set of $n = 1,\\ldots,N$ training observations, we can compute the average of the loss function over all observations such that $H\\left(p,q\\right)$ becomes\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "    J(\\mathrm{w}) = \\frac{1}{N}\\sum_{n=1}^{N}H\\left(p_{n},q_{n}\\right) \n",
+    "    = -\\frac{1}{N}\\sum_{n=1}^{N} \\begin{bmatrix} y_{n}\\mathrm{log}\\hat{y}_{n} + \\left(1-y_{n}\\right)\\mathrm{log}\\left(1-\\hat{y}_{n}\\right) \\end{bmatrix}.\n",
+    "    \\end{align}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae2e097e",
+   "metadata": {},
+   "source": [
+    "#### Cross-entropy loss function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f84b851",
+   "metadata": {},
+   "source": [
+    "The cross-entropy loss function is defined for a training sample $x_{i}$ belonging to class $j$ as\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "    loss\\left(x, y; w\\right) &= H\\left(y, \\hat{y}\\right) = \\sum_{j} y_{j}\\mathrm{log}\\hat{y}_{j} = -\\mathrm{log}\\frac{\\mathcal{e}^{w_{j}^{\\top}x_{i}}}{\\sum_{j=1}^{k} \\mathcal{e}^{w_{j}^{\\top}x_{i}}}\n",
+    "    \\end{align}\n",
+    "$$\n",
+    "where $y$ denotes the [one-hot](https://en.wikipedia.org/wiki/One-hot) encoded vector and $\\hat{y}$ denotes the probability distribution $h\\left(x_{i}\\right)$.\n",
+    "\n",
+    "The cross-entropy loss function for all observations $\\left(\\mathrm{X}_{i}, \\mathrm{Y}_{i}\\right)_{i=1}^{N}$ is then\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "    loss\\left(\\mathrm{X}, \\mathrm{Y}; \\mathrm{w}\\right) = -\\sum_{i=1}^{N}\\sum_{j=1}^{k} I\\left[y_{i} = j\\right]\\mathrm{log}\\frac{\\mathcal{e}^{w_{j}^{\\top}x_{i}}}{\\sum_{j=1}^{k}\\mathcal{e}^{w_{j}^{\\top} x_{i}}}\n",
+    "    \\end{align}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1b777c1",
    "metadata": {},
    "source": [
     "## 2. Programming Task"
@@ -153,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22d4e643",
+   "id": "ae821c84",
    "metadata": {},
    "source": [
     "### 2.1. Softmax"
@@ -208,31 +273,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "fcadaedb",
+   "execution_count": 45,
+   "id": "d81e48d9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0.02364054, 0.06426166, 0.1746813 , 0.474833  , 0.02364054,\n",
-       "       0.06426166, 0.1746813 ])"
+       "array([0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
+       "       0.10902364, 0.29635698])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "### Testing the softmax function\n",
-    "a = [1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0]\n",
-    "softmax(a)"
+    "### Testing the softmax function with N=7 predictions\n",
+    "x = [1.0, 2.0, 3.0, 1.0, 2.0, 2.0, 3.0]\n",
+    "x_scaled = softmax(x)\n",
+    "x_scaled"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "624c3489",
+   "id": "c7968a04",
    "metadata": {},
    "source": [
     "### 2.2. Cross-entropy"
@@ -248,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 30,
    "id": "ae0b187c",
    "metadata": {},
    "outputs": [],
@@ -258,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 31,
    "id": "340e7f8e",
    "metadata": {},
    "outputs": [],
@@ -273,12 +339,98 @@
     "    - loss [tensor]: cross entropy \n",
     "    \"\"\"\n",
     "    # IMPLEMENT THIS FUNCTION\n",
-    "    return nll"
+    "    \n",
+    "    n_classes = one_hot.shape[0]\n",
+    "    class_label = one_hot.argmax(axis=1)\n",
+    "    log_likelihood = -np.log(scaled_logits[:n_classes, class_label])\n",
+    "    loss = np.sum(log_likelihood) / n_classes\n",
+    "    return loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "1af1a4ae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0., 0., 1., 0.],\n",
+       "       [0., 0., 1., 0.],\n",
+       "       [0., 0., 0., 1.],\n",
+       "       [1., 0., 0., 0.],\n",
+       "       [0., 0., 1., 0.],\n",
+       "       [0., 1., 0., 0.],\n",
+       "       [0., 0., 0., 1.]], dtype=float32)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Creating our ground-truth labels and using one-hot encoding\n",
+    "y = np.array([2.0, 2.0, 3.0, 0.0, 2.0, 1.0, 3.0])\n",
+    "y_one_hot = utils.to_categorical(y, num_classes=np.unique(y).shape[0])\n",
+    "y_one_hot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "133c50ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
+       "        0.10902364, 0.29635698],\n",
+       "       [0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
+       "        0.10902364, 0.29635698],\n",
+       "       [0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
+       "        0.10902364, 0.29635698]])"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "### Creating pseudo-batched prediction data by repeating 'predictions'\n",
+    "X_scaled = np.stack([x_scaled] * 3)\n",
+    "X_scaled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "e26ed492",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6.648571590055648"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "### Testing the cross-entropy loss function with N=1 batch\n",
+    "loss = cross_entropy(X_scaled, y_one_hot)\n",
+    "loss"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3f7a0b25",
+   "id": "d190cd80",
    "metadata": {},
    "source": [
     "### 2.3. Logistic Regression model"
@@ -294,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "6b8cf3c2",
    "metadata": {},
    "outputs": [],
@@ -304,7 +456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "92083e35",
    "metadata": {},
    "outputs": [],
@@ -325,7 +477,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6aef47e0",
+   "id": "eeca9b93",
    "metadata": {},
    "source": [
     "### 2.4. Prediction accuracy"
@@ -341,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "06181bb3",
    "metadata": {},
    "outputs": [],
@@ -351,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "4bf1feff",
    "metadata": {},
    "outputs": [],
@@ -388,17 +540,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74a3db93",
+   "id": "051aadeb",
    "metadata": {},
    "source": [
     "## Credits\n",
     "This assignment was prepared by Thomas Hossler and Michael Virgo et al., Winter 2021 (link [here](https://www.udacity.com/course/self-driving-car-engineer-nanodegree--nd0013)).\n",
     "\n",
     "References\n",
+    "* [1] Ji, S. Xie, Y. Logistic Regression: From Binary to Multi-Class. http://people.tamu.edu/~sji/classes/LR.pdf\n",
     "\n",
     "\n",
     "Helpful resources:\n",
-    "* [Softmax Regression and How is it Related to Logistic Regression? | KDnuggets](https://www.kdnuggets.com/2016/07/softmax-regression-related-logistic-regression.html)"
+    "* [Softmax Regression and How is it Related to Logistic Regression? | KDnuggets](https://www.kdnuggets.com/2016/07/softmax-regression-related-logistic-regression.html)\n",
+    "* [Softmax and Cross Entropy Loss | P. Dahal](https://deepnotes.io/softmax-crossentropy)"
    ]
   }
  ],

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2637bfb0",
+   "id": "a6cff2c3",
    "metadata": {},
    "source": [
     "#### By Jonathan L. Moran (jonathan.moran107@gmail.com)"
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b84553eb",
+   "id": "9deebd11",
    "metadata": {},
    "source": [
     "From the Self-Driving Car Engineer Nanodegree programme offered at Udacity."
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b0a29da",
+   "id": "61ee5847",
    "metadata": {},
    "source": [
     "In this exercise we will implement the following functions:\n",
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a515ce59",
+   "id": "0875f35b",
    "metadata": {},
    "source": [
     "## 1. Introduction"
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "08880264",
+   "id": "d04e42a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ecf90fa2",
+   "id": "e4e1b2cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "5c9f8b43",
+   "id": "da1e789e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "18169047",
+   "id": "701e4e59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "42fa8d89",
+   "id": "93ec9c8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "224cb7ca",
+   "id": "4c5cbfa0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d570bae",
+   "id": "5af51377",
    "metadata": {},
    "source": [
     "### 1.1. Softmax"
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fab2d1d",
+   "id": "b043cb12",
    "metadata": {},
    "source": [
     "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9de254df",
+   "id": "830dfd8b",
    "metadata": {},
    "source": [
     "##### Note on numerical stability"
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec96da9d",
+   "id": "3c54300c",
    "metadata": {},
    "source": [
     "Exponentiation in Python can be a problem for larger numbers. A Numpy `float64` value can represent a maximal number on the order of $10^{308}$, but with exponentiation in the softmax function it is possible to overshoot this number, even for fairly modest-sized inputs (as pointed out in [this](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) post by E. Bendersky).\n",
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e25f95d2",
+   "id": "f913c309",
    "metadata": {},
    "source": [
     "### 1.2. Cross-entropy"
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da1b914c",
+   "id": "87839cc9",
    "metadata": {},
    "source": [
     "In machine learning, [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_loss_function_and_logistic_regression) is often used as a loss function computed between two probability distributions. Given a set of predictions $q_{i}$ and corresponding true probability values $p_{i}$ we can compute the cross-entropy loss, i.e., _log loss_ [1],\n",
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2485d48",
+   "id": "47afe92a",
    "metadata": {},
    "source": [
     "#### Cross-entropy loss function"
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "957342cb",
+   "id": "a2efbdaa",
    "metadata": {},
    "source": [
     "The cross-entropy loss function is defined for a training sample $x_{i}$ belonging to class $j$ as\n",
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b24df7a5",
+   "id": "a54dce75",
    "metadata": {},
    "source": [
     "## 2. Programming Task"
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "633d9220",
+   "id": "f02b646d",
    "metadata": {},
    "source": [
     "### 2.1. Softmax"
@@ -295,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "9bf4924c",
+   "id": "66947710",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,15 +320,15 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "79899ecc",
+   "id": "4f3fefac",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-08-29 12:53:27.349766: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
-      "2022-08-29 12:53:27.350226: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "2022-08-29 13:05:35.503853: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
+      "2022-08-29 13:05:35.504289: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
      ]
     },
@@ -357,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "522826a6",
+   "id": "49fd83ef",
    "metadata": {},
    "outputs": [
     {
@@ -380,7 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "decf5fe6",
+   "id": "57e1eff7",
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2edb691a",
+   "id": "ff421951",
    "metadata": {},
    "source": [
     "**Note**: this output isn't very ideal either, since the softmax function does not typically result in a zero value. However, for very large numbers, we are expecting a result extremely close to zero anyway."
@@ -410,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4c50701",
+   "id": "1ac3334a",
    "metadata": {},
    "source": [
     "### 2.2. Cross-entropy"
@@ -468,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "2a2be59c",
+   "id": "970dc73e",
    "metadata": {},
    "outputs": [
     {
@@ -499,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "3946a2ef",
+   "id": "3c1e002f",
    "metadata": {},
    "outputs": [
     {
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd4b4593",
+   "id": "e61d9d84",
    "metadata": {},
    "source": [
     "**Note**: this data does not make any sense in the scheme of this problem, we are simply the output of our cross-entropy loss function. "
@@ -537,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f5072882",
+   "id": "08b1aa35",
    "metadata": {},
    "outputs": [
     {
@@ -559,7 +559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7560f37",
+   "id": "8daf9726",
    "metadata": {},
    "source": [
     "### 2.3. Logistic Regression model"
@@ -601,6 +601,9 @@
     "    \"\"\"\n",
     "    # IMPLEMENT THIS FUNCTION\n",
     "    \n",
+    "    assert isinstance(X, tf.Tensor)\n",
+    "    assert isinstance(W, tf.Variable)\n",
+    "    assert isinstance(b, tf.Variable)\n",
     "    # Compute the product between flattened input and weight vectors\n",
     "    Z = tf.matmul(tf.reshape(X, shape=(-1, W.shape[0])), W)\n",
     "    # Add the bias term\n",
@@ -611,7 +614,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "133a7e3d",
+   "id": "af57a089",
    "metadata": {},
    "source": [
     "### 2.4. Prediction accuracy"
@@ -643,21 +646,30 @@
    "outputs": [],
    "source": [
     "def accuracy(y_hat, y):\n",
-    "    \"\"\"\n",
-    "    calculate accuracy\n",
-    "    args:\n",
-    "    - y_hat [tensor]: NxC tensor of models predictions\n",
-    "    - y [tensor]: N tensor of ground truth classes\n",
-    "    returns:\n",
-    "    - acc [tensor]: accuracy\n",
+    "    \"\"\"Calculates the average correct predictions.\n",
+    "\n",
+    "    :param y_hat: tf.Tensor, NxC tensor-like object of \n",
+    "        models predictions [n_samples x n_classes].\n",
+    "    :param y: tf.Tensor, N-dimensional tensor of\n",
+    "        ground truth class labels (not one-hot encoded).\n",
+    "    returns: acc, a 1x1 scalar tf.Tensor-like object\n",
+    "        with the accuracy score (correct / total predictions).\n",
     "    \"\"\"\n",
     "    # IMPLEMENT THIS FUNCTION\n",
+    "    \n",
+    "    assert isinstance(y, tf.Tensor) and isinstance(y_hat, tf.Tensor)\n",
+    "    # Get predicted labels with highest probabilities\n",
+    "    y_preds = tf.cast(tf.math.argmax(y_hat, axis=1), dtype=y.dtype)\n",
+    "    # Get number of correct predictions\n",
+    "    n_correct = tf.math.count_nonzero(tf.cast(tf.math.equal(y_preds, y), dtype=tf.int32))\n",
+    "    # Compute average correct predictions\n",
+    "    acc = n_correct / y_hat.shape[0]\n",
     "    return acc"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2bfb1967",
+   "id": "737590c5",
    "metadata": {},
    "source": [
     "### 2.5. Evaluation"
@@ -665,7 +677,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b6d7ed4",
+   "id": "d1fa63c5",
    "metadata": {},
    "source": [
     "We will check the above functions against the provided test values given by Udacity."
@@ -674,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "2e1739cf",
+   "id": "443ad942",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "db88d1d4",
+   "id": "4190834f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "a5e34120",
+   "id": "f6a0951b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "55ca6f49",
+   "id": "e49fa68a",
    "metadata": {},
    "outputs": [
     {
@@ -760,7 +772,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "7a64c7fc",
+   "id": "802632d1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +782,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "f0b71222",
+   "id": "978fd661",
    "metadata": {},
    "outputs": [
     {
@@ -788,7 +800,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "fcaa429f",
+   "id": "bcc1baf5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,7 +810,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "038a1687",
+   "id": "56df1113",
    "metadata": {},
    "outputs": [
     {
@@ -816,7 +828,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "1d91962e",
+   "id": "4c71bbd0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,16 +838,24 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "b64526aa",
+   "id": "62193f18",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy implementation is correct!\n"
+     ]
+    }
+   ],
    "source": [
-    "#check_acc(accuracy)"
+    "check_acc(accuracy)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d9c3b8d8",
+   "id": "4749b0d7",
    "metadata": {},
    "source": [
     "## 3. Closing Remarks"
@@ -843,13 +863,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "979ab753",
+   "id": "92a5f892",
    "metadata": {},
    "source": [
     "##### Alternatives\n",
     "* Use `tf.nn.softmax_cross_entropy_with_logits` instead of manually-computing the softmax and cross-entropy loss functions;\n",
     "* Use `tf.boolean_mask` instead of Numpy multidimensional array indexing in `cross_entropy` to \"mask\" correct class prediction probabilities;\n",
-    "* Regularisation by multiplying an `alpha` hyperparameter with the product of the cross-entropy and L2 weight vector losses.\n",
+    "* Regularisation by multiplying an `alpha` hyperparameter with the product of the cross-entropy and L2 weight vector losses;\n",
     "* Perform maximum likelihood estimation and optimisation using the `tf.train.GradientDescentOptimizer.mimimize(loss)` function.\n",
     "\n",
     "##### Extensions of task\n",
@@ -859,7 +879,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23fbc124",
+   "id": "6958504d",
    "metadata": {},
    "source": [
     "## Credits\n",

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "226d04ed",
+   "id": "2637bfb0",
    "metadata": {},
    "source": [
     "#### By Jonathan L. Moran (jonathan.moran107@gmail.com)"
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b979664f",
+   "id": "b84553eb",
    "metadata": {},
    "source": [
     "From the Self-Driving Car Engineer Nanodegree programme offered at Udacity."
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac1be90b",
+   "id": "5b0a29da",
    "metadata": {},
    "source": [
     "In this exercise we will implement the following functions:\n",
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b24afe77",
+   "id": "a515ce59",
    "metadata": {},
    "source": [
     "## 1. Introduction"
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "d5605c6d",
+   "id": "08880264",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "15f55668",
+   "id": "ecf90fa2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "de001b48",
+   "id": "5c9f8b43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b70fb15b",
+   "id": "18169047",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "9de4350c",
+   "id": "42fa8d89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "f651f693",
+   "id": "224cb7ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a12ea3f8",
+   "id": "3d570bae",
    "metadata": {},
    "source": [
     "### 1.1. Softmax"
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4ee36bd",
+   "id": "8fab2d1d",
    "metadata": {},
    "source": [
     "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c43814d3",
+   "id": "9de254df",
    "metadata": {},
    "source": [
     "##### Note on numerical stability"
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9abe1c2",
+   "id": "ec96da9d",
    "metadata": {},
    "source": [
     "Exponentiation in Python can be a problem for larger numbers. A Numpy `float64` value can represent a maximal number on the order of $10^{308}$, but with exponentiation in the softmax function it is possible to overshoot this number, even for fairly modest-sized inputs (as pointed out in [this](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) post by E. Bendersky).\n",
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b183d4c8",
+   "id": "e25f95d2",
    "metadata": {},
    "source": [
     "### 1.2. Cross-entropy"
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef1b9984",
+   "id": "da1b914c",
    "metadata": {},
    "source": [
     "In machine learning, [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_loss_function_and_logistic_regression) is often used as a loss function computed between two probability distributions. Given a set of predictions $q_{i}$ and corresponding true probability values $p_{i}$ we can compute the cross-entropy loss, i.e., _log loss_ [1],\n",
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e9057c4",
+   "id": "f2485d48",
    "metadata": {},
    "source": [
     "#### Cross-entropy loss function"
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3f03b25",
+   "id": "957342cb",
    "metadata": {},
    "source": [
     "The cross-entropy loss function is defined for a training sample $x_{i}$ belonging to class $j$ as\n",
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ddfc7f1",
+   "id": "b24df7a5",
    "metadata": {},
    "source": [
     "## 2. Programming Task"
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d8d3dfa",
+   "id": "633d9220",
    "metadata": {},
    "source": [
     "### 2.1. Softmax"
@@ -295,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "d144aedb",
+   "id": "9bf4924c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,15 +320,15 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b22ac0e6",
+   "id": "79899ecc",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-08-28 19:41:36.465409: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
-      "2022-08-28 19:41:36.466833: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "2022-08-29 12:53:27.349766: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
+      "2022-08-29 12:53:27.350226: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
      ]
     },
@@ -357,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "c7b62cdf",
+   "id": "522826a6",
    "metadata": {},
    "outputs": [
     {
@@ -380,7 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "307037d8",
+   "id": "decf5fe6",
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +402,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aca89c15",
+   "id": "2edb691a",
    "metadata": {},
    "source": [
     "**Note**: this output isn't very ideal either, since the softmax function does not typically result in a zero value. However, for very large numbers, we are expecting a result extremely close to zero anyway."
@@ -410,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9b098e5",
+   "id": "e4c50701",
    "metadata": {},
    "source": [
     "### 2.2. Cross-entropy"
@@ -453,13 +453,14 @@
     "    \n",
     "    assert isinstance(scaled_logits, tf.Tensor)\n",
     "    assert isinstance(one_hot, tf.Tensor)\n",
-    "    assert scaled_logits.shape == y_one_hot.shape\n",
     "    n_samples = one_hot.shape[0]\n",
     "    class_labels = tf.math.argmax(one_hot, axis=1)\n",
     "    # For each sample, pick the probability value from the distribution\n",
     "    # that corresponds to the true class label\n",
     "    preds = tnp.asarray(scaled_logits)[range(n_samples), class_labels]\n",
+    "    # Taking the negative log-likelihood\n",
     "    log_likelihood = -tf.math.log(preds)\n",
+    "    # Normalising by the sample size\n",
     "    loss = tf.math.reduce_sum(log_likelihood) / n_samples\n",
     "    return loss"
    ]
@@ -467,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "17922ebe",
+   "id": "2a2be59c",
    "metadata": {},
    "outputs": [
     {
@@ -498,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "c7e9170a",
+   "id": "3946a2ef",
    "metadata": {},
    "outputs": [
     {
@@ -526,9 +527,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dd4b4593",
+   "metadata": {},
+   "source": [
+    "**Note**: this data does not make any sense in the scheme of this problem, we are simply the output of our cross-entropy loss function. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "479b9123",
+   "id": "f5072882",
    "metadata": {},
    "outputs": [
     {
@@ -550,7 +559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e327561a",
+   "id": "d7560f37",
    "metadata": {},
    "source": [
     "### 2.3. Logistic Regression model"
@@ -582,22 +591,27 @@
    "outputs": [],
    "source": [
     "def model(X, W, b):\n",
-    "    \"\"\"\n",
-    "    logistic regression model\n",
-    "    args:\n",
-    "    - X [tensor]: input HxWx3\n",
-    "    - W [tensor]: weights\n",
-    "    - b [tensor]: bias\n",
-    "    returns:\n",
-    "    - output [tensor]\n",
+    "    \"\"\"Performs one step of the logistic regression model.\n",
+    "    \n",
+    "    :param X: tf.Tensor object, a training observation\n",
+    "        i.e., a single HxWx3 RGB image.\n",
+    "    :param W: tf.Tensor object, the weight vector.\n",
+    "    :param b: the bias term, tf.Tensor-like object.\n",
+    "    returns: tf.Tensor, the softmax probability distribution.\n",
     "    \"\"\"\n",
     "    # IMPLEMENT THIS FUNCTION\n",
-    "    return "
+    "    \n",
+    "    # Compute the product between flattened input and weight vectors\n",
+    "    Z = tf.matmul(tf.reshape(X, shape=(-1, W.shape[0])), W)\n",
+    "    # Add the bias term\n",
+    "    Z += b\n",
+    "    # Return the softmax probabilities P\n",
+    "    return softmax(Z)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "bb28285f",
+   "id": "133a7e3d",
    "metadata": {},
    "source": [
     "### 2.4. Prediction accuracy"
@@ -628,7 +642,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def accuracy(y_hat, Y):\n",
+    "def accuracy(y_hat, y):\n",
     "    \"\"\"\n",
     "    calculate accuracy\n",
     "    args:\n",
@@ -643,24 +657,209 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17d8b2e1",
+   "id": "2bfb1967",
    "metadata": {},
    "source": [
-    "## Tips"
+    "### 2.5. Evaluation"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "be159df3",
+   "id": "9b6d7ed4",
    "metadata": {},
    "source": [
-    "You can leverage the `tf.boolean_mask` function to calculate the cross entropy. Keep in mind\n",
-    "that most elements of the ground truth vector are zeros."
+    "We will check the above functions against the provided test values given by Udacity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "2e1739cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### From Udacity's `utils.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "db88d1d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_softmax(func):\n",
+    "    logits = tf.constant([[0.5, 1.0, 2.0, 0.3, 4.0]])\n",
+    "    tf_soft = tf.nn.softmax(logits)\n",
+    "    soft = func(logits)\n",
+    "    l1_norm = tf.norm(tf_soft - soft, ord=1)\n",
+    "    assert l1_norm < 1e-5, 'Softmax calculation is wrong'\n",
+    "    print('Softmax implementation is correct!')\n",
+    "\n",
+    "\n",
+    "def check_ce(func):\n",
+    "    logits = tf.constant([[0.5, 1.0, 2.0, 0.3, 4.0]])\n",
+    "    scaled_logits = tf.nn.softmax(logits)\n",
+    "    one_hot = tf.constant([[0, 0, 0, 0, 1.0]])\n",
+    "    tf_ce = tf.nn.softmax_cross_entropy_with_logits(one_hot, logits)\n",
+    "    ce = func(scaled_logits, one_hot)\n",
+    "    l1_norm = tf.norm(tf_ce - ce, ord=1)\n",
+    "    assert l1_norm < 1e-5, 'CE calculation is wrong'\n",
+    "    print('CE implementation is correct!')\n",
+    "\n",
+    "\n",
+    "def check_model(func):\n",
+    "    # only check the output size here\n",
+    "    X = tf.random.uniform([28, 28, 3])\n",
+    "    num_inputs = 28*28*3\n",
+    "    num_outputs = 10\n",
+    "    W = tf.Variable(tf.random.normal(shape=(num_inputs, num_outputs),\n",
+    "                                    mean=0, stddev=0.01))\n",
+    "    b = tf.Variable(tf.zeros(num_outputs))\n",
+    "    out = func(X, W, b)\n",
+    "    assert out.shape == (1, 10), 'Model is wrong!'\n",
+    "    print('Model implementation is correct!')\n",
+    "\n",
+    "\n",
+    "def check_acc(func):\n",
+    "    y_hat = tf.constant([[0.8, 0.2, 0.5, 0.2, 5.0], [0.8, 0.2, 0.5, 0.2, 5.0]]) \n",
+    "    y = tf.constant([4, 1])\n",
+    "    acc = func(y_hat, y)\n",
+    "    assert acc == tf.cast(tf.constant(0.5), dtype=acc.dtype), 'Accuracy calculation is wrong!'\n",
+    "    print('Accuracy implementation is correct!')    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "a5e34120",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Testing the `softmax` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "55ca6f49",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Softmax implementation is correct!\n"
+     ]
+    }
+   ],
+   "source": [
+    "check_softmax(softmax)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "7a64c7fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Testing the cross-entropy loss function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "f0b71222",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CE implementation is correct!\n"
+     ]
+    }
+   ],
+   "source": [
+    "check_ce(cross_entropy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "fcaa429f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Testing the logistic regression `model` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "038a1687",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model implementation is correct!\n"
+     ]
+    }
+   ],
+   "source": [
+    "check_model(model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "1d91962e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Testing the `accuracy` scoring function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "b64526aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#check_acc(accuracy)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a90acbad",
+   "id": "d9c3b8d8",
+   "metadata": {},
+   "source": [
+    "## 3. Closing Remarks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "979ab753",
+   "metadata": {},
+   "source": [
+    "##### Alternatives\n",
+    "* Use `tf.nn.softmax_cross_entropy_with_logits` instead of manually-computing the softmax and cross-entropy loss functions;\n",
+    "* Use `tf.boolean_mask` instead of Numpy multidimensional array indexing in `cross_entropy` to \"mask\" correct class prediction probabilities;\n",
+    "* Regularisation by multiplying an `alpha` hyperparameter with the product of the cross-entropy and L2 weight vector losses.\n",
+    "* Perform maximum likelihood estimation and optimisation using the `tf.train.GradientDescentOptimizer.mimimize(loss)` function.\n",
+    "\n",
+    "##### Extensions of task\n",
+    "* Implement a `fit` function that performs the gradient descent optimisation over a number of epochs;\n",
+    "* Alternatively, use a `tf.Session` to iterate over model computations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23fbc124",
    "metadata": {},
    "source": [
     "## Credits\n",
@@ -673,7 +872,9 @@
     "Helpful resources:\n",
     "* [Softmax Regression and How is it Related to Logistic Regression? | KDnuggets](https://www.kdnuggets.com/2016/07/softmax-regression-related-logistic-regression.html)\n",
     "* [The Softmax function and its derivative | E. Bendersky](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/)\n",
-    "* [Softmax and Cross Entropy Loss | P. Dahal](https://deepnotes.io/softmax-crossentropy)"
+    "* [Softmax and Cross Entropy Loss | P. Dahal](https://deepnotes.io/softmax-crossentropy)\n",
+    "* [Multinomial Regression with TensorFlow | YouTube](https://www.youtube.com/watch?v=2JiXktBn_2M)\n",
+    "* [Logistic regression 5.2: Multiclass - Softmax regression | YouTube](https://www.youtube.com/watch?v=hYBwBmojXoU)"
    ]
   }
  ],

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a6cff2c3",
+   "id": "cf5d4af3",
    "metadata": {},
    "source": [
     "#### By Jonathan L. Moran (jonathan.moran107@gmail.com)"
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9deebd11",
+   "id": "849eda0a",
    "metadata": {},
    "source": [
     "From the Self-Driving Car Engineer Nanodegree programme offered at Udacity."
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61ee5847",
+   "id": "ddbb119d",
    "metadata": {},
    "source": [
     "In this exercise we will implement the following functions:\n",
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0875f35b",
+   "id": "0f95f0b9",
    "metadata": {},
    "source": [
     "## 1. Introduction"
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "d04e42a6",
+   "id": "b20398d3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e4e1b2cd",
+   "id": "41ee3698",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,13 +73,14 @@
     "import os\n",
     "import tensorflow as tf\n",
     "import tensorflow.experimental.numpy as tnp\n",
-    "from tensorflow.keras import utils"
+    "from tensorflow.keras import utils\n",
+    "import timeit"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "da1e789e",
+   "id": "965c13ba",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "701e4e59",
+   "id": "641c0582",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "93ec9c8e",
+   "id": "979a4964",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "4c5cbfa0",
+   "id": "be243290",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5af51377",
+   "id": "219506ce",
    "metadata": {},
    "source": [
     "### 1.1. Softmax"
@@ -130,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b043cb12",
+   "id": "1792816f",
    "metadata": {},
    "source": [
     "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
@@ -154,7 +155,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "830dfd8b",
+   "id": "9b0d381d",
    "metadata": {},
    "source": [
     "##### Note on numerical stability"
@@ -162,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c54300c",
+   "id": "5fb5eb59",
    "metadata": {},
    "source": [
     "Exponentiation in Python can be a problem for larger numbers. A Numpy `float64` value can represent a maximal number on the order of $10^{308}$, but with exponentiation in the softmax function it is possible to overshoot this number, even for fairly modest-sized inputs (as pointed out in [this](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) post by E. Bendersky).\n",
@@ -188,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f913c309",
+   "id": "d6736b7b",
    "metadata": {},
    "source": [
     "### 1.2. Cross-entropy"
@@ -196,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87839cc9",
+   "id": "ef6e41f6",
    "metadata": {},
    "source": [
     "In machine learning, [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_loss_function_and_logistic_regression) is often used as a loss function computed between two probability distributions. Given a set of predictions $q_{i}$ and corresponding true probability values $p_{i}$ we can compute the cross-entropy loss, i.e., _log loss_ [1],\n",
@@ -221,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47afe92a",
+   "id": "ab4d8ef5",
    "metadata": {},
    "source": [
     "#### Cross-entropy loss function"
@@ -229,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2efbdaa",
+   "id": "0429e727",
    "metadata": {},
    "source": [
     "The cross-entropy loss function is defined for a training sample $x_{i}$ belonging to class $j$ as\n",
@@ -252,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a54dce75",
+   "id": "6e68a031",
    "metadata": {},
    "source": [
     "## 2. Programming Task"
@@ -260,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f02b646d",
+   "id": "5645cd09",
    "metadata": {},
    "source": [
     "### 2.1. Softmax"
@@ -295,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "66947710",
+   "id": "e3692834",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,15 +321,15 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "4f3fefac",
+   "id": "e0fe998d",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-08-29 13:05:35.503853: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
-      "2022-08-29 13:05:35.504289: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "2022-08-29 13:30:32.785538: I tensorflow/compiler/jit/xla_cpu_device.cc:41] Not creating XLA devices, tf_xla_enable_xla_devices not set\n",
+      "2022-08-29 13:30:32.785899: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
      ]
     },
@@ -357,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "49fd83ef",
+   "id": "f4c34ed9",
    "metadata": {},
    "outputs": [
     {
@@ -380,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "57e1eff7",
+   "id": "897a681e",
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff421951",
+   "id": "118b16b0",
    "metadata": {},
    "source": [
     "**Note**: this output isn't very ideal either, since the softmax function does not typically result in a zero value. However, for very large numbers, we are expecting a result extremely close to zero anyway."
@@ -410,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ac3334a",
+   "id": "1ecc617a",
    "metadata": {},
    "source": [
     "### 2.2. Cross-entropy"
@@ -437,29 +438,47 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "b127373f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import timeit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "id": "340e7f8e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def cross_entropy(scaled_logits, one_hot):\n",
+    "def cross_entropy(scaled_logits, one_hot, use_numpy=True):\n",
     "    \"\"\"Returns the cross-entropy loss.\n",
     "    \n",
     "    :param scaled_logits: an NxC tf.Tensor of scaled softmax\n",
     "        distribution values, [n_samples x n_classes].\n",
     "    :param one_hot: an NxC tf.Tensor of one-hot encoded \n",
     "        ground truth labels, [n_samples x n_classes].\n",
+    "    :param use_numpy: optional, uses  Numpy multidimensional\n",
+    "        array indexing on type-casted tf.experimental.numpy\n",
+    "        ndarrays, uses boolean masking if False.\n",
     "    :returns: loss, a 1x1 tf.Tensor with cross-entropy loss. \n",
     "    \"\"\"\n",
     "    \n",
     "    assert isinstance(scaled_logits, tf.Tensor)\n",
     "    assert isinstance(one_hot, tf.Tensor)\n",
-    "    n_samples = one_hot.shape[0]\n",
-    "    class_labels = tf.math.argmax(one_hot, axis=1)\n",
-    "    # For each sample, pick the probability value from the distribution\n",
-    "    # that corresponds to the true class label\n",
-    "    preds = tnp.asarray(scaled_logits)[range(n_samples), class_labels]\n",
-    "    # Taking the negative log-likelihood\n",
-    "    log_likelihood = -tf.math.log(preds)\n",
+    "    if use_numpy:\n",
+    "        n_samples = one_hot.shape[0]\n",
+    "        class_labels = tf.math.argmax(one_hot, axis=1)\n",
+    "        preds = tnp.asarray(scaled_logits)[range(n_samples), class_labels]\n",
+    "        log_likelihood = -tf.math.log(preds)\n",
+    "    else:\n",
+    "        n_samples = one_hot.shape[0]\n",
+    "        # For each sample, pick the probability value from the distribution\n",
+    "        # that corresponds to the true class label\n",
+    "        preds = tf.boolean_mask(scaled_logits, one_hot)\n",
+    "        # Taking the negative log-likelihood\n",
+    "        log_likelihood = -tf.math.log(preds)\n",
     "    # Normalising by the sample size\n",
     "    loss = tf.math.reduce_sum(log_likelihood) / n_samples\n",
     "    return loss"
@@ -467,8 +486,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "970dc73e",
+   "execution_count": 15,
+   "id": "01832e0e",
    "metadata": {},
    "outputs": [
     {
@@ -484,7 +503,7 @@
        "       [0., 0., 0., 1.]], dtype=float32)>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -498,8 +517,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "3c1e002f",
+   "execution_count": 16,
+   "id": "02b8b339",
    "metadata": {},
    "outputs": [
     {
@@ -515,7 +534,7 @@
        "       [0.29635698, 0.29635698, 0.29635698, 0.29635698]])>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -528,7 +547,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e61d9d84",
+   "id": "cce927b6",
    "metadata": {},
    "source": [
     "**Note**: this data does not make any sense in the scheme of this problem, we are simply the output of our cross-entropy loss function. "
@@ -536,8 +555,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "08b1aa35",
+   "execution_count": 17,
+   "id": "3331e1f2",
    "metadata": {},
    "outputs": [
     {
@@ -546,7 +565,7 @@
        "<tf.Tensor: shape=(), dtype=float64, numpy=2.216190530018549>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -559,7 +578,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8daf9726",
+   "id": "4f6f2ca3",
    "metadata": {},
    "source": [
     "### 2.3. Logistic Regression model"
@@ -575,7 +594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "6b8cf3c2",
    "metadata": {},
    "outputs": [],
@@ -585,7 +604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "92083e35",
    "metadata": {},
    "outputs": [],
@@ -614,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af57a089",
+   "id": "182c2598",
    "metadata": {},
    "source": [
     "### 2.4. Prediction accuracy"
@@ -630,7 +649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "06181bb3",
    "metadata": {},
    "outputs": [],
@@ -640,7 +659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "4bf1feff",
    "metadata": {},
    "outputs": [],
@@ -669,7 +688,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "737590c5",
+   "id": "f1d454cd",
    "metadata": {},
    "source": [
     "### 2.5. Evaluation"
@@ -677,7 +696,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1fa63c5",
+   "id": "6e229b27",
    "metadata": {},
    "source": [
     "We will check the above functions against the provided test values given by Udacity."
@@ -685,8 +704,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "443ad942",
+   "execution_count": 22,
+   "id": "ceb929fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -695,8 +714,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "4190834f",
+   "execution_count": 23,
+   "id": "5299c164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,13 +757,19 @@
     "    y = tf.constant([4, 1])\n",
     "    acc = func(y_hat, y)\n",
     "    assert acc == tf.cast(tf.constant(0.5), dtype=acc.dtype), 'Accuracy calculation is wrong!'\n",
-    "    print('Accuracy implementation is correct!')    "
+    "    print('Accuracy implementation is correct!') \n",
+    "    \n",
+    "def compute_ce(func, use_numpy):\n",
+    "    logits = tf.constant([[0.5, 1.0, 2.0, 0.3, 4.0]])\n",
+    "    scaled_logits = tf.nn.softmax(logits)\n",
+    "    one_hot = tf.constant([[0, 0, 0, 0, 1.0]])\n",
+    "    ce = func(scaled_logits, one_hot, use_numpy)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "f6a0951b",
+   "execution_count": 24,
+   "id": "697b5b28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,8 +778,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "e49fa68a",
+   "execution_count": 25,
+   "id": "feac9e21",
    "metadata": {},
    "outputs": [
     {
@@ -771,8 +796,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "id": "802632d1",
+   "execution_count": 26,
+   "id": "d406ee18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,8 +806,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "978fd661",
+   "execution_count": 27,
+   "id": "25d58160",
    "metadata": {},
    "outputs": [
     {
@@ -799,8 +824,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "bcc1baf5",
+   "execution_count": 28,
+   "id": "7ceefe74",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0012832483039999997"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Testing single execution time using `tf.boolean_mask`\n",
+    "timeit.timeit(lambda: compute_ce(cross_entropy, use_numpy=False), number=1000) / 1000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "d45ba349",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0018046973149999995"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Testing average execution time using Numpy indexing\n",
+    "timeit.timeit(lambda: compute_ce(cross_entropy, use_numpy=True), number=1000) / 1000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "ea3b6372",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,8 +878,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "id": "56df1113",
+   "execution_count": 31,
+   "id": "193bca1d",
    "metadata": {},
    "outputs": [
     {
@@ -827,8 +896,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "4c71bbd0",
+   "execution_count": 32,
+   "id": "34620937",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -837,8 +906,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "62193f18",
+   "execution_count": 33,
+   "id": "b7758acd",
    "metadata": {},
    "outputs": [
     {
@@ -855,7 +924,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4749b0d7",
+   "id": "6c81fb61",
    "metadata": {},
    "source": [
     "## 3. Closing Remarks"
@@ -863,7 +932,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92a5f892",
+   "id": "ff0bfefc",
    "metadata": {},
    "source": [
     "##### Alternatives\n",
@@ -879,7 +948,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6958504d",
+   "id": "f249d982",
    "metadata": {},
    "source": [
     "## Credits\n",

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf5d4af3",
+   "id": "268f1c9a",
    "metadata": {},
    "source": [
     "#### By Jonathan L. Moran (jonathan.moran107@gmail.com)"
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "849eda0a",
+   "id": "df86bbb0",
    "metadata": {},
    "source": [
     "From the Self-Driving Car Engineer Nanodegree programme offered at Udacity."
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddbb119d",
+   "id": "bd5d7a91",
    "metadata": {},
    "source": [
     "In this exercise we will implement the following functions:\n",
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f95f0b9",
+   "id": "f9a4df85",
    "metadata": {},
    "source": [
     "## 1. Introduction"
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b20398d3",
+   "id": "577cbcf1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "41ee3698",
+   "id": "afc3c9f2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "965c13ba",
+   "id": "ccd57c20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "641c0582",
+   "id": "0e60cd7e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "979a4964",
+   "id": "aa1b4b0d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "be243290",
+   "id": "07119181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "219506ce",
+   "id": "6e358a4c",
    "metadata": {},
    "source": [
     "### 1.1. Softmax"
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1792816f",
+   "id": "1a0c68d5",
    "metadata": {},
    "source": [
     "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b0d381d",
+   "id": "565378ab",
    "metadata": {},
    "source": [
     "##### Note on numerical stability"
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fb5eb59",
+   "id": "ba080c26",
    "metadata": {},
    "source": [
     "Exponentiation in Python can be a problem for larger numbers. A Numpy `float64` value can represent a maximal number on the order of $10^{308}$, but with exponentiation in the softmax function it is possible to overshoot this number, even for fairly modest-sized inputs (as pointed out in [this](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) post by E. Bendersky).\n",
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6736b7b",
+   "id": "fa80545f",
    "metadata": {},
    "source": [
     "### 1.2. Cross-entropy"
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef6e41f6",
+   "id": "93022444",
    "metadata": {},
    "source": [
     "In machine learning, [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_loss_function_and_logistic_regression) is often used as a loss function computed between two probability distributions. Given a set of predictions $q_{i}$ and corresponding true probability values $p_{i}$ we can compute the cross-entropy loss, i.e., _log loss_ [1],\n",
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab4d8ef5",
+   "id": "af5ee29e",
    "metadata": {},
    "source": [
     "#### Cross-entropy loss function"
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0429e727",
+   "id": "f61c6033",
    "metadata": {},
    "source": [
     "The cross-entropy loss function is defined for a training sample $x_{i}$ belonging to class $j$ as\n",
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e68a031",
+   "id": "a83917bf",
    "metadata": {},
    "source": [
     "## 2. Programming Task"
@@ -261,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5645cd09",
+   "id": "37076f1c",
    "metadata": {},
    "source": [
     "### 2.1. Softmax"
@@ -296,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e3692834",
+   "id": "4a2c9f7a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e0fe998d",
+   "id": "fb09b00a",
    "metadata": {},
    "outputs": [
     {
@@ -358,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f4c34ed9",
+   "id": "1462cd04",
    "metadata": {},
    "outputs": [
     {
@@ -381,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "897a681e",
+   "id": "7f27e893",
    "metadata": {},
    "outputs": [
     {
@@ -403,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "118b16b0",
+   "id": "a068bcd7",
    "metadata": {},
    "source": [
     "**Note**: this output isn't very ideal either, since the softmax function does not typically result in a zero value. However, for very large numbers, we are expecting a result extremely close to zero anyway."
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ecc617a",
+   "id": "e4bc9e35",
    "metadata": {},
    "source": [
     "### 2.2. Cross-entropy"
@@ -438,7 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "b127373f",
+   "id": "974d2693",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "01832e0e",
+   "id": "c72dd809",
    "metadata": {},
    "outputs": [
     {
@@ -518,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "02b8b339",
+   "id": "ac494019",
    "metadata": {},
    "outputs": [
     {
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cce927b6",
+   "id": "59f5756b",
    "metadata": {},
    "source": [
     "**Note**: this data does not make any sense in the scheme of this problem, we are simply the output of our cross-entropy loss function. "
@@ -556,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "3331e1f2",
+   "id": "0a87f187",
    "metadata": {},
    "outputs": [
     {
@@ -578,7 +578,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f6f2ca3",
+   "id": "cf756c0e",
    "metadata": {},
    "source": [
     "### 2.3. Logistic Regression model"
@@ -618,7 +618,6 @@
     "    :param b: the bias term, tf.Tensor-like object.\n",
     "    returns: tf.Tensor, the softmax probability distribution.\n",
     "    \"\"\"\n",
-    "    # IMPLEMENT THIS FUNCTION\n",
     "    \n",
     "    assert isinstance(X, tf.Tensor)\n",
     "    assert isinstance(W, tf.Variable)\n",
@@ -633,7 +632,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "182c2598",
+   "id": "f01700ab",
    "metadata": {},
    "source": [
     "### 2.4. Prediction accuracy"
@@ -674,7 +673,6 @@
     "    returns: acc, a 1x1 scalar tf.Tensor-like object\n",
     "        with the accuracy score (correct / total predictions).\n",
     "    \"\"\"\n",
-    "    # IMPLEMENT THIS FUNCTION\n",
     "    \n",
     "    assert isinstance(y, tf.Tensor) and isinstance(y_hat, tf.Tensor)\n",
     "    # Get predicted labels with highest probabilities\n",
@@ -688,7 +686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1d454cd",
+   "id": "1953a203",
    "metadata": {},
    "source": [
     "### 2.5. Evaluation"
@@ -696,7 +694,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e229b27",
+   "id": "5261ddb8",
    "metadata": {},
    "source": [
     "We will check the above functions against the provided test values given by Udacity."
@@ -705,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "ceb929fa",
+   "id": "ff92e15c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +713,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "5299c164",
+   "id": "13c8a111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -758,6 +756,7 @@
     "    acc = func(y_hat, y)\n",
     "    assert acc == tf.cast(tf.constant(0.5), dtype=acc.dtype), 'Accuracy calculation is wrong!'\n",
     "    print('Accuracy implementation is correct!') \n",
+    "\n",
     "    \n",
     "def compute_ce(func, use_numpy):\n",
     "    logits = tf.constant([[0.5, 1.0, 2.0, 0.3, 4.0]])\n",
@@ -769,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "697b5b28",
+   "id": "c9fcd931",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,7 +778,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "feac9e21",
+   "id": "4c2884bf",
    "metadata": {},
    "outputs": [
     {
@@ -797,7 +796,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "d406ee18",
+   "id": "5a5cf15d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -807,7 +806,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "25d58160",
+   "id": "30db7680",
    "metadata": {},
    "outputs": [
     {
@@ -825,7 +824,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "7ceefe74",
+   "id": "d48415f2",
    "metadata": {},
    "outputs": [
     {
@@ -840,14 +839,14 @@
     }
    ],
    "source": [
-    "# Testing single execution time using `tf.boolean_mask`\n",
+    "# Testing average execution time using `tf.boolean_mask`\n",
     "timeit.timeit(lambda: compute_ce(cross_entropy, use_numpy=False), number=1000) / 1000"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "d45ba349",
+   "id": "8fd5e330",
    "metadata": {},
    "outputs": [
     {
@@ -869,7 +868,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "ea3b6372",
+   "id": "3876d13a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -879,7 +878,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "193bca1d",
+   "id": "7a12ddac",
    "metadata": {},
    "outputs": [
     {
@@ -897,7 +896,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "34620937",
+   "id": "4f7ced75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,7 +906,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "b7758acd",
+   "id": "b52e89a3",
    "metadata": {},
    "outputs": [
     {
@@ -924,7 +923,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c81fb61",
+   "id": "68abc791",
    "metadata": {},
    "source": [
     "## 3. Closing Remarks"
@@ -932,7 +931,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff0bfefc",
+   "id": "16457d23",
    "metadata": {},
    "source": [
     "##### Alternatives\n",
@@ -948,7 +947,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f249d982",
+   "id": "8340a946",
+   "metadata": {},
+   "source": [
+    "## 4. Future Work"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "931ad1d6",
+   "metadata": {},
+   "source": [
+    "- [ ] Run model on actual training data;\n",
+    "- [ ] Use built-in TensorFlow methods for further performance optimisations;\n",
+    "- [ ] Encapsulate current model with `fit` function and perform mini-batched or stochastic gradient descent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7088d60a",
    "metadata": {},
    "source": [
     "## Credits\n",

--- a/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
+++ b/1-Object-Detection-in-Urban-Environments/Exercises/1-3-1-Logistic-Regression/2022-08-27-Logistic-Regression.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1501ac3",
+   "id": "331a320e",
    "metadata": {},
    "source": [
     "In this exercise we will implement the following functions:\n",
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "010dcb91",
+   "id": "153113ba",
    "metadata": {},
    "source": [
     "## 1. Introduction"
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d2983a13",
+   "id": "2308d786",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "b3f0b4c1",
+   "id": "9188c02c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7d88c5c2",
+   "id": "38607790",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "27fa02d1",
+   "id": "02bfb36f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "fbbfa20a",
+   "id": "4d6db820",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "b05aa651",
+   "id": "bbb7c93d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aba03402",
+   "id": "493ffc8e",
    "metadata": {},
    "source": [
     "### 1.1. Softmax"
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21be5228",
+   "id": "483020bd",
    "metadata": {},
    "source": [
     "The [softmax function](https://en.wikipedia.org/wiki/Softmax_function) is a generalisation of the sigmoid [logistic function](https://en.wikipedia.org/wiki/Logistic_function) to multiple dimensions. In machine learning, particularly for logistic regression, the softmax function $\\phi$ acts as a decision boundary applied to multi-class datasets, computing the probability of each observation $x_{i}$ belonging to one of $j = i,...,k$ class labels (assuming an independent relationship between the classes),\n",
@@ -146,7 +146,41 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9476d5d",
+   "id": "c2b1f8ed",
+   "metadata": {},
+   "source": [
+    "##### Note on numerical stability"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9ce3acf",
+   "metadata": {},
+   "source": [
+    "Exponentiation in Python can be a problem for larger numbers. A Numpy `float64` value can represent a maximal number on the order of $10^{308}$, but with exponentiation in the softmax function it is possible to overshoot this number, even for fairly modest-sized inputs (as pointed out in [this](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) post by E. Bendersky).\n",
+    "\n",
+    "To handle this, we can normalise the inputs using an arbitrary constant $C$ and moving it into the exponent to obtain\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "    \\phi_{softmax}\\left(z_{i}\\right) \n",
+    "    = \\frac{C\\mathcal{e}^{z_{i}}}{\\sum_{j=0}^{k}C\\mathcal{e}^{z_{k}^{i}}} = \\frac{\\mathcal{e}^{z_{i} + \\mathrm{log}\\left(C\\right)}}{\\sum_{j=0}^{k}C\\mathcal{e}^{z_{k}^{i} + \\mathrm{log}\\left(C\\right)}}.\n",
+    "    \\end{align}\n",
+    "$$\n",
+    "\n",
+    "Replacing $\\mathrm{log}\\left(C\\right)$ with another arbitrary constant $D$, we can then select a value for $D$ as follows\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "    D = -max\\left(x_{1}, x_{2},\\ldots,x_{N}\\right) \n",
+    "    \\end{align}\n",
+    "$$\n",
+    "such that all input observations $x$ will be shifted towards zero with _negative_ values. Because of this, we can better avoid NaNs as negatives with large exponents \"saturate\" to zero rather than infinity."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afe82f54",
    "metadata": {},
    "source": [
     "### 1.2. Cross-entropy"
@@ -154,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81fb2f35",
+   "id": "7309acfc",
    "metadata": {},
    "source": [
     "In machine learning, [cross-entropy](https://en.wikipedia.org/wiki/Cross_entropy#Cross-entropy_loss_function_and_logistic_regression) is often used as a loss function computed between two probability distributions. Given a set of predictions $q_{i}$ and corresponding true probability values $p_{i}$ we can compute the cross-entropy loss, i.e., _log loss_ [1],\n",
@@ -179,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae2e097e",
+   "id": "b49ca1fb",
    "metadata": {},
    "source": [
     "#### Cross-entropy loss function"
@@ -187,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f84b851",
+   "id": "0f4e32f4",
    "metadata": {},
    "source": [
     "The cross-entropy loss function is defined for a training sample $x_{i}$ belonging to class $j$ as\n",
@@ -203,14 +237,14 @@
     "\n",
     "$$\n",
     "\\begin{align}\n",
-    "    loss\\left(\\mathrm{X}, \\mathrm{Y}; \\mathrm{w}\\right) = -\\sum_{i=1}^{N}\\sum_{j=1}^{k} I\\left[y_{i} = j\\right]\\mathrm{log}\\frac{\\mathcal{e}^{w_{j}^{\\top}x_{i}}}{\\sum_{j=1}^{k}\\mathcal{e}^{w_{j}^{\\top} x_{i}}}\n",
+    "    loss\\left(\\mathrm{X}, \\mathrm{Y}; \\mathrm{w}\\right) = -\\sum_{i=1}^{N}\\sum_{j=1}^{k} I\\left[y_{i} = j\\right]\\mathrm{log}\\frac{\\mathcal{e}^{w_{j}^{\\top}x_{i}}}{\\sum_{j=1}^{k}\\mathcal{e}^{w_{j}^{\\top} x_{i}}}.\n",
     "    \\end{align}\n",
     "$$"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e1b777c1",
+   "id": "48fd42ea",
    "metadata": {},
    "source": [
     "## 2. Programming Task"
@@ -218,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae821c84",
+   "id": "7fedb148",
    "metadata": {},
    "source": [
     "### 2.1. Softmax"
@@ -252,29 +286,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 55,
    "id": "d144aedb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def softmax(logits):\n",
-    "    \"\"\"\n",
-    "    softmax implementation\n",
-    "    args:\n",
-    "    - logits [tensor]: 1xN logits tensor\n",
-    "    returns:\n",
-    "    - soft_logits [tensor]: softmax of logits\n",
-    "    \"\"\"\n",
-    "    # IMPLEMENT THIS FUNCTION\n",
+    "def softmax(logits, stable=False):\n",
+    "    \"\"\"Returns the softmax probability distribution.\n",
     "    \n",
+    "    :param logits: a 1xN tensor of logits.\n",
+    "    :param stable: optional, flag indicating whether\n",
+    "        or not to normalise the input data.\n",
+    "    returns: soft_logits, an 1xN tensor of real values\n",
+    "        in range (0,1) that sum up to 1.0.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # TODO: perform on tensor objects\n",
+    "    if stable:\n",
+    "        logits -= np.max(logits)\n",
     "    soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n",
     "    return soft_logits"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
-   "id": "d81e48d9",
+   "execution_count": 56,
+   "id": "1ab041f0",
    "metadata": {},
    "outputs": [
     {
@@ -284,7 +321,7 @@
        "       0.10902364, 0.29635698])"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -297,8 +334,72 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "5ff7ec9e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/wf/qk186lys1kd1yhnstdfyjjr80000gn/T/ipykernel_87737/1200169668.py:14: RuntimeWarning: overflow encountered in exp\n",
+      "  soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n",
+      "/var/folders/wf/qk186lys1kd1yhnstdfyjjr80000gn/T/ipykernel_87737/1200169668.py:14: RuntimeWarning: invalid value encountered in true_divide\n",
+      "  soft_logits = np.exp(logits) / np.sum(np.exp(logits))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([nan, nan, nan])"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "### Testing the softmax function with N=3 large values (without normalising)\n",
+    "x_large = [1000, 2000, 3000]\n",
+    "softmax(x_large)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "85209812",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0., 0., 1.])"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "### Testing the softmax function with N=3 large values (with normalising)\n",
+    "x_large = [1000, 2000, 3000]\n",
+    "softmax(x_large, stable=True)"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "c7968a04",
+   "id": "89f978eb",
+   "metadata": {},
+   "source": [
+    "**Note**: this output isn't very ideal either, since the softmax function does not typically result in a zero value. However, for very large numbers, we are expecting a result extremely close to zero anyway."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faea6156",
    "metadata": {},
    "source": [
     "### 2.2. Cross-entropy"
@@ -324,22 +425,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 65,
    "id": "340e7f8e",
    "metadata": {},
    "outputs": [],
    "source": [
     "def cross_entropy(scaled_logits, one_hot):\n",
-    "    \"\"\"\n",
-    "    Cross entropy loss implementation\n",
-    "    args:\n",
-    "    - scaled_logits [tensor]: NxC tensor where N batch size / C number of classes\n",
-    "    - one_hot [tensor]: one hot tensor\n",
-    "    returns:\n",
-    "    - loss [tensor]: cross entropy \n",
-    "    \"\"\"\n",
-    "    # IMPLEMENT THIS FUNCTION\n",
+    "    \"\"\"Returns the cross-entropy loss.\n",
     "    \n",
+    "    :param scaled_logits: an NxC tensor of scaled softmax\n",
+    "        distribution values, [n_samples x n_classes].\n",
+    "    :param one_hot: an CxN tensor of one-hot encoded \n",
+    "        ground truth labels, [n_classes x n_samples].\n",
+    "    :returns: loss, a 1x1 tensor with cross-entropy loss. \n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # TODO: perform on tensor objects\n",
+    "    assert scaled_logits.shape == one_hot.T.shape\n",
     "    n_classes = one_hot.shape[0]\n",
     "    class_label = one_hot.argmax(axis=1)\n",
     "    log_likelihood = -np.log(scaled_logits[:n_classes, class_label])\n",
@@ -349,8 +451,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
-   "id": "1af1a4ae",
+   "execution_count": 75,
+   "id": "be3caa17",
    "metadata": {},
    "outputs": [
     {
@@ -365,7 +467,7 @@
        "       [0., 0., 0., 1.]], dtype=float32)"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -379,8 +481,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
-   "id": "133c50ee",
+   "execution_count": 76,
+   "id": "ca2f43ca",
    "metadata": {},
    "outputs": [
     {
@@ -391,33 +493,35 @@
        "       [0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
        "        0.10902364, 0.29635698],\n",
        "       [0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
+       "        0.10902364, 0.29635698],\n",
+       "       [0.04010756, 0.10902364, 0.29635698, 0.04010756, 0.10902364,\n",
        "        0.10902364, 0.29635698]])"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "### Creating pseudo-batched prediction data by repeating 'predictions'\n",
-    "X_scaled = np.stack([x_scaled] * 3)\n",
+    "### Creating pseudo-batched data by repeating 'predictions'\n",
+    "X_scaled = np.stack([x_scaled] * 4)\n",
     "X_scaled"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
-   "id": "e26ed492",
+   "execution_count": 77,
+   "id": "12b86f4b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "6.648571590055648"
+       "8.864762120074198"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -430,7 +534,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d190cd80",
+   "id": "98de1fa3",
    "metadata": {},
    "source": [
     "### 2.3. Logistic Regression model"
@@ -477,7 +581,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eeca9b93",
+   "id": "aa7151ec",
    "metadata": {},
    "source": [
     "### 2.4. Prediction accuracy"
@@ -540,7 +644,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "051aadeb",
+   "id": "0726f8a5",
    "metadata": {},
    "source": [
     "## Credits\n",
@@ -552,8 +656,17 @@
     "\n",
     "Helpful resources:\n",
     "* [Softmax Regression and How is it Related to Logistic Regression? | KDnuggets](https://www.kdnuggets.com/2016/07/softmax-regression-related-logistic-regression.html)\n",
+    "* [The Softmax function and its derivative | E. Bendersky](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/)\n",
     "* [Softmax and Cross Entropy Loss | P. Dahal](https://deepnotes.io/softmax-crossentropy)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15996404",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR merges branch `1.3.1` into `main`. All assignment tasks from Exercise 1.3.1 have now been completed.

#### More info
The following methods have been added:
* `softmax`: computes the softmax probability distribution of an input tensor;
* `cross_entropy`: returns the cross-entropy loss given a vector-like tensor of scaled (softmax) prediction values and tensor of one-hot encoded ground-truth class labels;
* `model`: performs a single update of the logistic regression model given a tensor-like training observation, a tensor-like weight vector and a tensor-like bias term as inputs;
*  `accuracy`: computes the average number of correct predictions given a set of tensor-like predicted and ground truth class labels.